### PR TITLE
Automatically look up for the icons page

### DIFF
--- a/YammerSketchTools.sketchplugin/Contents/Sketch/Icons/ExportIcons.js
+++ b/YammerSketchTools.sketchplugin/Contents/Sketch/Icons/ExportIcons.js
@@ -24,7 +24,6 @@
 var onRun = function(context) {
   try {
     var doc = context.document,
-      currentPage = doc.currentPage(),
       scriptPath = context.scriptPath,
       homeFolder = "/Users/" + NSUserName();
 
@@ -38,7 +37,7 @@ var onRun = function(context) {
       } else {
 
         // looking for the artboard named 'icons'
-        var iconsPage = io.mamuso.tools.findObjectsByName("icons", currentPage.artboards()).firstObject();
+        var iconsPage = io.mamuso.tools.findObjectsByName("icons", doc.pages()).firstObject();
 
         if(iconsPage == null) {
           return;


### PR DESCRIPTION
Improvement: user doesn't need to specifically select the 'icons' page anymore to run the plugin.